### PR TITLE
Fixed quiz question Url.

### DIFF
--- a/src/client/quizApp/components/QLFreetext/QLFreetext.jsx
+++ b/src/client/quizApp/components/QLFreetext/QLFreetext.jsx
@@ -125,7 +125,7 @@ var QLFreetext = React.createClass({
                     <QLQuestion
                         questionData={this.props.questionData}
                     />
-                    {this.props.questionData.imageURL ? <QLImage src={`https://d15tuytjqnsden.cloudfront.net/${this.props.questionData.imageURL}`} className='ql-question-img'/> : null}
+                    {this.props.questionData.imageURL ? <QLImage src={this.props.questionData.imageURL} className='ql-question-img'/> : null}
                     {showCountdown}
                     <div className="answers">
                         {showAnswer}

--- a/src/client/quizApp/components/QLMultiple/QLMultiple.jsx
+++ b/src/client/quizApp/components/QLMultiple/QLMultiple.jsx
@@ -137,7 +137,7 @@ var QLMultiple = React.createClass({
                     <QLQuestion
                         questionData={this.props.questionData}
                     />
-                    {this.props.questionData.imageURL ? <QLImage src={`https://d15tuytjqnsden.cloudfront.net/${this.props.questionData.imageURL}`} className='ql-question-img'/> : null}
+                    {this.props.questionData.imageURL ? <QLImage src={this.props.questionData.imageURL} className='ql-question-img'/> : null}
                     {showCountdown}
                     <div className="answers alternatives">
                         {showAnswer}

--- a/src/client/quizApp/components/QLScrambled/QLScrambled.jsx
+++ b/src/client/quizApp/components/QLScrambled/QLScrambled.jsx
@@ -276,7 +276,8 @@ var QLScrambled = React.createClass({
                             questionData={this.props.questionData}
                         />
                     </h3>
-                    {this.props.questionData.imageURL ? <QLImage src={`https://d15tuytjqnsden.cloudfront.net/${this.props.questionData.imageURL}`} className='ql-question-img'/> : null}
+
+                    {this.props.questionData.imageURL ? <QLImage src={this.props.questionData.imageURL} className='ql-question-img'/> : null}
                     {showCountdown}
                     <div className="answers options">
                         {showAnswer}


### PR DESCRIPTION
Prop this.props.questionData.imageURL sometimes can contain full image Url so error occurs when trying to add cdn url before it. CDN Url is added inside QLImage imageUrlParser() so there is no need to add it before.
![broken_question_image](https://cloud.githubusercontent.com/assets/2144180/11022342/303bb252-8654-11e5-8f09-d33091416a25.png)
