### PR TITLE
workaround the key error in function searchThroughCategories()

### DIFF
--- a/src/client/quizApp/factories/QuizData.js
+++ b/src/client/quizApp/factories/QuizData.js
@@ -247,12 +247,14 @@ angular.module('quizApp').factory('QuizData', function($http, $log, $rootScope){
 
     var searchThroughCategories = function(catId, quizId) {
         console.log('categories', categories, catId, quizId);
-        for (var i in categories[catId].quizzes) {
-            var quiz = categories[catId].quizzes[i];
-            if (quiz.uuid == quizId) {
-                setQuiz(quiz);
-                return currentQuiz;
-            }
+        if (categories[catId]) {
+          for (var i in categories[catId].quizzes) {
+              var quiz = categories[catId].quizzes[i];
+              if (quiz.uuid == quizId) {
+                  setQuiz(quiz);
+                  return currentQuiz;
+              }
+          }
         }
         for (var p in categories) {
             for (var i in categories[p].quizzes) {


### PR DESCRIPTION
We are using a mix of uuid and plaintext as category keys, and then caused some key error. 
See if iterate all keys solves this problem.