### PR TITLE
Bugfix: Answer and Question always shows empty fields.

### DIFF
--- a/src/client/quizApp/components/QLAnswerScreen/QLAnswerScreen.jsx
+++ b/src/client/quizApp/components/QLAnswerScreen/QLAnswerScreen.jsx
@@ -92,7 +92,9 @@ var QLAnswerScreen = React.createClass({
         var correctAnswer, viewVideo, videoPlayer, explanation;
         var hasPartialScore = 0 < this.props.answerData.partial && this.props.answerData.partial < 1;
         var questionType = this.props.questionData.answerObject ? this.props.questionData.answerObject.type : "";
-        var answer = "", response = "";
+        var answer = this.props.answerData.answer;
+        var response = this.props.answerData.response;
+
 
         if (this.props.answerData.correct){
             for (var i = 0; i < 30; i++){


### PR DESCRIPTION
As *answer* and *response* variables are not defined, answer screen show empty fields.

<img width="1268" alt="screen shot 2015-11-22 at 16 09 10" src="https://cloud.githubusercontent.com/assets/2144180/11324786/14204912-9134-11e5-910d-5ac1c4f071bd.png">

@blaiprat 